### PR TITLE
Delay initial overlay menu rendering

### DIFF
--- a/ShaderInjector/HookD3D12.cpp
+++ b/ShaderInjector/HookD3D12.cpp
@@ -78,6 +78,8 @@ namespace HookD3D12
 	static FrameContext* gFrameContexts = nullptr;
 	static bool          gInitialized = false;
 	static bool          gShutdown = false;
+	static ULONGLONG     gOverlayInitializedTick = 0;
+	static bool          gLoggedStartupMenuDelay = false;
 	static bool          gOverlayRenderingDisabled = false;
 	static bool          gAfterFirstPresent = false;
 	static bool          gLoggedPresentHook = false;
@@ -1741,6 +1743,8 @@ namespace HookD3D12
 		
 			// Hook CommandQueue and Fence are already captured by minhook
 			gInitialized = true;
+			if (!gOverlayInitializedTick)
+				gOverlayInitializedTick = GetTickCount64();
 			if (!gLoggedOverlayInitialized)
 			{
 				ShaderInjectorIO::WriteToLogFile("HookD3D12->HandlePresentD3D12: Overlay initialized from present path");
@@ -1765,6 +1769,16 @@ namespace HookD3D12
 
 		if (!Globals::gShowShaderInjectorGUI || gOverlayRenderingDisabled)
 			return CallOriginalPresent();
+
+		if (gOverlayInitializedTick && GetTickCount64() - gOverlayInitializedTick < 5000)
+		{
+			if (!gLoggedStartupMenuDelay)
+			{
+				ShaderInjectorIO::WriteToLogFile("HookD3D12->HandlePresentD3D12: delaying startup menu render until overlay is stable");
+				gLoggedStartupMenuDelay = true;
+			}
+			return CallOriginalPresent();
+		}
 
 		if (!gShutdown) 
 		{


### PR DESCRIPTION
﻿## Summary

Adds a short delay before rendering the ImGui overlay menu immediately after D3D12 overlay initialization.

## Why

On some Windows Store / WinGDK builds, starting with the menu already open can render the overlay too early during startup. Delaying only the first visible menu draw gives the swapchain and overlay resources a few seconds to settle while preserving the existing startup initialization path.

## Impact

- Only affects the case where the ShaderInjector menu is visible immediately after overlay initialization.
- Does not change hotkeys, shader replacement behavior, D3D12 hooks, or pipeline parsing.
- Users can still open the menu normally after startup.

## Validation

Built successfully with MSBuild:

`ShaderInjector.sln /p:Configuration=Release /p:Platform=x64`

Build completed with existing warnings and no errors.
