### PR TITLE
Use window messages for menu hotkeys

### DIFF
--- a/ShaderInjector/HookD3D12.cpp
+++ b/ShaderInjector/HookD3D12.cpp
@@ -1756,18 +1756,6 @@ namespace HookD3D12
 
 		InstallCommandListHooks();
 
-		if (GetAsyncKeyState(Globals::keyOpenShaderInjectorGUI) & 1)
-		{
-			Globals::gShowShaderInjectorGUI = !Globals::gShowShaderInjectorGUI;
-			//ShaderInjectorGUI::WriteToRuntimeLog("HookD3D12->HandlePresentD3D12: Shader Injector GUI " + (gShowShaderInjectorGUI ? "Enabled" : "Disabled"));
-		}
-
-		if (GetAsyncKeyState(Globals::keyToggleShaderInjector) & 1)
-		{
-			Globals::gShaderInjectorEnabled = !Globals::gShaderInjectorEnabled;
-			MarkShaderReplacementApplyDirty();
-			//ShaderInjectorGUI::WriteToRuntimeLog("HookD3D12->HandlePresentD3D12: Shader Injector " + (gShaderInjectorEnabled ? "Enabled" : "Disabled"));
-		}
 
 		if (!Globals::gShowShaderInjectorGUI || gOverlayRenderingDisabled)
 			return CallOriginalPresent();

--- a/ShaderInjector/HookInput.cpp
+++ b/ShaderInjector/HookInput.cpp
@@ -77,6 +77,25 @@ namespace HookInput
 		auto originalWindowProcedureIterator = sOriginalWindowProcedures.find(windowHandle);
 		WNDPROC originalWindowProcedure = (originalWindowProcedureIterator != sOriginalWindowProcedures.end()) ? originalWindowProcedureIterator->second : nullptr;
 
+		const bool isFreshKeyDown = (message == WM_KEYDOWN || message == WM_SYSKEYDOWN) && (longParameter & 0x40000000) == 0;
+		if (isFreshKeyDown)
+		{
+			const int key = static_cast<int>(wordParameter);
+
+			if (key == Globals::keyOpenShaderInjectorGUI)
+			{
+				Globals::gShowShaderInjectorGUI = !Globals::gShowShaderInjectorGUI;
+				return TRUE;
+			}
+
+			if (key == Globals::keyToggleShaderInjector)
+			{
+				Globals::gShaderInjectorEnabled = !Globals::gShaderInjectorEnabled;
+				HookD3D12::MarkShaderReplacementApplyDirty();
+				return TRUE;
+			}
+		}
+
 		if (Globals::gShowShaderInjectorGUI && HookD3D12::IsInitialized() && ImGui::GetCurrentContext())
 		{
 			if (ImGui_ImplWin32_WndProcHandler(windowHandle, message, wordParameter, longParameter))


### PR DESCRIPTION
﻿## Summary

This moves the ShaderInjector menu hotkeys from frame polling with `GetAsyncKeyState()` into the existing game-window WndProc hook.

The existing `ShaderInjector.ini` keybinds are preserved:

- `OpenMenuKey` still toggles the menu
- `ToggleInjectorKey` still toggles the injector

## Why

On the Windows Store / WinGDK version of Final Fantasy VII Rebirth, the overlay can render correctly and the startup menu can appear, but runtime hotkey polling with `GetAsyncKeyState()` can be unreliable. In local testing, Insert/Home-style polling either did not trigger or produced delayed/double toggles.

ShaderInjector already subclasses the game window and forwards input to ImGui, so handling fresh `WM_KEYDOWN` / `WM_SYSKEYDOWN` messages there keeps hotkey input on the same path as the rest of the menu input.

## Changes

- Handle configured menu/injector hotkeys in `HookInput::WndProc`.
- Ignore repeated keydown messages so holding a key does not rapid-toggle.
- Remove the old Present-loop `GetAsyncKeyState()` hotkey polling to avoid duplicate toggles.

## Validation

- Built `Release|x64` successfully with MSBuild.
- Locally tested on the Windows Store / WinGDK FFVII Rebirth build: startup menu still opens, Insert toggles the menu reliably, and Home keeps using the existing configured toggle key path.

Existing build warnings remain unchanged.
