### PR TITLE
chore(logging): Add logging around shader discovery

### DIFF
--- a/ShaderInjector/ShaderAutomaticDiscovery.cpp
+++ b/ShaderInjector/ShaderAutomaticDiscovery.cpp
@@ -2,6 +2,7 @@
 
 #include <deque>
 #include <algorithm>
+#include <chrono>
 #include <condition_variable>
 #include <cstdlib>
 #include <memory>
@@ -19,6 +20,7 @@
 #include "ShaderAnalysis.h"
 #include "ShaderDiscovery.h"
 #include "ShaderInjectorGUI.h"
+#include "StringHelper.h"
 
 namespace ShaderAutomaticDiscovery
 {
@@ -82,7 +84,12 @@ namespace ShaderAutomaticDiscovery
 		std::unordered_map<ShaderKey, std::string, ShaderKeyHasher> gDirectMatchShaders;
 		std::shared_ptr<const std::vector<ModifiedShader::PackageDisk>> gModifiedShaderAnalysisSnapshot;
 		bool gCompatibleShaderTypes[static_cast<size_t>(ShaderTarget::Unknown) + 1]{};
+		bool gSeenShaderTypes[static_cast<size_t>(ShaderTarget::Unknown) + 1]{};
 		std::vector<std::pair<size_t, size_t>> gPlausibleByteLengthRanges[static_cast<size_t>(ShaderTarget::Unknown) + 1];
+		std::chrono::steady_clock::time_point gSessionStartTime{};
+		bool gSessionStartTimeInitialized = false;
+		bool gNeverSeenShaderTypeDiagnosticLogged = false;
+		constexpr std::chrono::seconds neverSeenShaderTypeDiagnosticDelay{60};
 		std::condition_variable gAnalysisCondition;
 		std::thread* gAnalysisWorker = nullptr;
 		bool gAnalysisWorkerRunning = false;
@@ -185,11 +192,29 @@ namespace ShaderAutomaticDiscovery
 			{
 				return true;
 			}
+			gSeenShaderTypes[shaderTypeIndex] = true;
 			const auto directMatchIterator = gDirectMatchShaders.find(key);
 			const bool directMatch = directMatchIterator != gDirectMatchShaders.end() &&
 				!directMatchIterator->second.empty();
 			if (!force && !directMatch && !HasPlausibleByteLength(shaderType, shaderBytecode.size()))
+			{
+				std::string expectedRanges;
+				const std::vector<std::pair<size_t, size_t>>& ranges = gPlausibleByteLengthRanges[shaderTypeIndex];
+				for (size_t rangeIndex = 0; rangeIndex < ranges.size(); ++rangeIndex)
+				{
+					if (rangeIndex > 0)
+						expectedRanges += ", ";
+					expectedRanges += std::to_string(ranges[rangeIndex].first) + "-" + std::to_string(ranges[rangeIndex].second);
+				}
+
+				ShaderInjectorGUI::WriteToRuntimeLogError(
+					"ShaderAutomaticDiscovery->Enqueue: byte length rejected for " +
+					StringHelper::ShaderTypeToString(shaderType) +
+					" hash=" + Hash::FormatHash(shaderHash) +
+					" byteLength=" + std::to_string(shaderBytecode.size()) +
+					(expectedRanges.empty() ? "" : " expectedRanges=[" + expectedRanges + "]"));
 				return true;
+			}
 
 			if (!force && !gSubmittedShaders.insert(key).second)
 				return true;
@@ -208,7 +233,13 @@ namespace ShaderAutomaticDiscovery
 			if (gQueuedShaders.size() >= maximumQueuedShaders)
 			{
 				if (!force)
+				{
+					ShaderInjectorGUI::WriteToRuntimeLogError(
+						"ShaderAutomaticDiscovery->Enqueue: queue full, dropping shader hash=" +
+						Hash::FormatHash(shaderHash) +
+						" queueSize=" + std::to_string(gQueuedShaders.size()));
 					return false;
+				}
 				gQueuedShaders.pop_back();
 			}
 
@@ -438,6 +469,73 @@ namespace ShaderAutomaticDiscovery
 			gAnalysisCondition.notify_one();
 			return true;
 		}
+
+		void CollectNeverSeenCompatibleShaderTypesForDiagnostic(std::vector<ShaderTarget::ShaderType>& outNeverSeenShaderTypes)
+		{
+			if (gNeverSeenShaderTypeDiagnosticLogged)
+				return;
+
+			if (!gSessionStartTimeInitialized)
+			{
+				gSessionStartTime = std::chrono::steady_clock::now();
+				gSessionStartTimeInitialized = true;
+				return;
+			}
+
+			if (std::chrono::steady_clock::now() - gSessionStartTime < neverSeenShaderTypeDiagnosticDelay)
+				return;
+
+			gNeverSeenShaderTypeDiagnosticLogged = true;
+
+			for (size_t shaderTypeIndex = 0; shaderTypeIndex < static_cast<size_t>(ShaderTarget::Unknown); ++shaderTypeIndex)
+			{
+				if (!gCompatibleShaderTypes[shaderTypeIndex] || gSeenShaderTypes[shaderTypeIndex])
+					continue;
+
+				outNeverSeenShaderTypes.push_back(static_cast<ShaderTarget::ShaderType>(shaderTypeIndex));
+			}
+		}
+
+		void LogNeverSeenCompatibleShaderTypes(const std::vector<ShaderTarget::ShaderType>& neverSeenShaderTypes)
+		{
+			if (neverSeenShaderTypes.empty())
+				return;
+
+			size_t enabledPackageCounts[static_cast<size_t>(ShaderTarget::Unknown) + 1]{};
+			size_t enabledReplacementCounts[static_cast<size_t>(ShaderTarget::Unknown) + 1]{};
+			for (const ModifiedShader::PackageDisk& modifiedShader : DatabaseModifiedShaders::GetModifiedShaders())
+			{
+				if (!modifiedShader.enabled || modifiedShader.shaderType == ShaderTarget::Unknown)
+					continue;
+
+				const size_t shaderTypeIndex = static_cast<size_t>(modifiedShader.shaderType);
+				if (shaderTypeIndex < static_cast<size_t>(ShaderTarget::Unknown))
+					++enabledPackageCounts[shaderTypeIndex];
+			}
+
+			if (HookD3D12::gLoadedShaderTargetsOnce)
+			{
+				for (const ShaderTarget::ShaderTargetDisk& replacement : HookD3D12::gLoadedShaderTargets)
+				{
+					if (!replacement.enabled || replacement.shaderType == ShaderTarget::Unknown)
+						continue;
+
+					const size_t shaderTypeIndex = static_cast<size_t>(replacement.shaderType);
+					if (shaderTypeIndex < static_cast<size_t>(ShaderTarget::Unknown))
+						++enabledReplacementCounts[shaderTypeIndex];
+				}
+			}
+
+			for (ShaderTarget::ShaderType shaderType : neverSeenShaderTypes)
+			{
+				const size_t shaderTypeIndex = static_cast<size_t>(shaderType);
+				ShaderInjectorGUI::WriteToRuntimeLogError(
+					"ShaderAutomaticDiscovery->MaybeLogNeverSeenCompatibleShaderTypes: no capture attempt for " +
+					StringHelper::ShaderTypeToString(shaderType) +
+					" enabledPackages=" + std::to_string(enabledPackageCounts[shaderTypeIndex]) +
+					" enabledReplacements=" + std::to_string(enabledReplacementCounts[shaderTypeIndex]));
+			}
+		}
 	}
 
 	void RefreshModifiedShaderIndex(const std::vector<ModifiedShader::PackageDisk>& modifiedShaders)
@@ -451,6 +549,8 @@ namespace ShaderAutomaticDiscovery
 		gDirectMatchShaders.clear();
 		for (bool& compatibleShaderType : gCompatibleShaderTypes)
 			compatibleShaderType = false;
+		for (bool& seenShaderType : gSeenShaderTypes)
+			seenShaderType = false;
 		for (auto& ranges : gPlausibleByteLengthRanges)
 			ranges.clear();
 
@@ -487,11 +587,14 @@ namespace ShaderAutomaticDiscovery
 
 	void ProcessQueuedWork(size_t maximumJobs)
 	{
+		std::vector<ShaderTarget::ShaderType> neverSeenShaderTypes;
 		{
 			std::lock_guard<std::mutex> lock(gQueueMutex);
 			if (!gAcceptingWork)
 				return;
+			CollectNeverSeenCompatibleShaderTypesForDiagnostic(neverSeenShaderTypes);
 		}
+		LogNeverSeenCompatibleShaderTypes(neverSeenShaderTypes);
 
 		// D3D12-facing completion work remains on the render thread.
 		for (size_t processedJobs = 0; processedJobs < maximumJobs; ++processedJobs)

--- a/ShaderInjector/ShaderDiscovery.cpp
+++ b/ShaderInjector/ShaderDiscovery.cpp
@@ -11,6 +11,7 @@
 #include "ShaderAnalyzer.h"
 #include "ShaderInjectorGUI.h"
 #include "ShaderInjectorIO.h"
+#include "StringHelper.h"
 
 namespace ShaderDiscovery
 {
@@ -191,6 +192,36 @@ namespace ShaderDiscovery
 
 		if (!HasStrictCrossVersionIdentity(candidateAnalysis))
 		{
+			std::string failureReason;
+			if (!candidateAnalysis.succeeded)
+			{
+				failureReason = candidateAnalysis.error.empty() ?
+					"analysis did not succeed" : candidateAnalysis.error;
+			}
+			else
+			{
+				auto appendMissingField = [&](const char* fieldName)
+				{
+					if (!failureReason.empty())
+						failureReason += ", ";
+					failureReason += fieldName;
+				};
+				if (candidateAnalysis.portableReflectionIdentityHash.empty())
+					appendMissingField("portableReflectionIdentityHash");
+				if (candidateAnalysis.semanticInstructionSetHash.empty())
+					appendMissingField("semanticInstructionSetHash");
+				if (candidateAnalysis.crossVersionIdentityHash.empty())
+					appendMissingField("crossVersionIdentityHash");
+				if (failureReason.empty())
+					failureReason = "unknown";
+			}
+
+			ShaderInjectorGUI::WriteToRuntimeLogError(
+				"ShaderDiscovery->DiscoverEnabledReplacement: " +
+				std::string(candidateAnalysis.succeeded ? "incomplete cross-version identity for " : "analysis failed for ") +
+				Hash::FormatHash(shaderHash) +
+				" type=" + StringHelper::ShaderTypeToString(shaderType) +
+				": " + failureReason);
 			gAttemptedCandidates.insert(candidateKey);
 			return -1;
 		}
@@ -478,6 +509,73 @@ namespace ShaderDiscovery
 					" score=" + std::to_string(bestScore));
 				return bestPackageIndex;
 			}
+
+			if (bestPackageIndex >= 0)
+			{
+				const ModifiedShader::PackageDisk& bestPackage = modifiedShaders[bestPackageIndex];
+				const ShaderAnalysis::ShaderAnalysisDisk* bestTargetAnalysis = nullptr;
+				double bestTargetScore = 0.0;
+				for (const ModifiedShader::TargetDisk& storedTarget : bestPackage.targets)
+				{
+					ModifiedShader::TargetDisk referenceTarget = storedTarget;
+					referenceTarget.knownShaderBytecodeHashes.clear();
+					ModifiedShader::TargetDisk candidateTarget{};
+					candidateTarget.targetApplication = referenceTarget.targetApplication;
+					candidateTarget.gameVersion = referenceTarget.gameVersion;
+					candidateTarget.originalShaderBytecodeLength = std::to_string(shaderBytecode.size());
+					candidateTarget.shaderAnalysis = candidateAnalysis;
+					const double targetScore = referenceTarget.CalculateSimilarityScore(candidateTarget);
+					if (targetScore > bestTargetScore)
+					{
+						bestTargetScore = targetScore;
+						bestTargetAnalysis = &storedTarget.shaderAnalysis;
+					}
+				}
+
+				std::string identityDiff;
+				if (bestTargetAnalysis)
+				{
+					auto appendDiff = [&](const char* label, const std::string& left, const std::string& right)
+					{
+						if (left != right)
+						{
+							if (!identityDiff.empty())
+								identityDiff += ", ";
+							identityDiff += std::string(label) + "=" + left + "!=" + right;
+						}
+					};
+					appendDiff("portableReflection",
+						candidateAnalysis.portableReflectionIdentityHash,
+						bestTargetAnalysis->portableReflectionIdentityHash);
+					appendDiff("semanticInstructionSet",
+						candidateAnalysis.semanticInstructionSetHash,
+						bestTargetAnalysis->semanticInstructionSetHash);
+					appendDiff("crossVersionIdentity",
+						candidateAnalysis.crossVersionIdentityHash,
+						bestTargetAnalysis->crossVersionIdentityHash);
+					appendDiff("entryFunction",
+						candidateAnalysis.entryFunctionName,
+						bestTargetAnalysis->entryFunctionName);
+				}
+
+				ShaderInjectorGUI::WriteToRuntimeLogError(
+					"ShaderDiscovery->DiscoverEnabledModifiedShader: analysis match rejected for " +
+					Hash::FormatHash(shaderHash) +
+					" bestScore=" + std::to_string(bestScore) +
+					" secondBestScore=" + std::to_string(secondBestScore) +
+					(identityDiff.empty() ? "" : " identityDiff={" + identityDiff + "}") +
+					" bestCandidate=" + bestPackage.id);
+			}
+		}
+		else
+		{
+			const std::string failureReason = candidateAnalysis.error.empty() ?
+				"analysis did not succeed" : candidateAnalysis.error;
+			ShaderInjectorGUI::WriteToRuntimeLogError(
+				"ShaderDiscovery->DiscoverEnabledModifiedShader: analysis failed for " +
+				Hash::FormatHash(shaderHash) +
+				" type=" + StringHelper::ShaderTypeToString(shaderType) +
+				": " + failureReason);
 		}
 #endif
 

--- a/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.cpp
+++ b/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.cpp
@@ -11,10 +11,10 @@ namespace CrossVersionDiscoveryTest
 {
 	namespace
 	{
-		// ShaderDiscovery.cpp lines 19-22
+		// ShaderDiscovery.cpp lines 22-23
 		constexpr double maximumReplacementByteLengthDifferenceRatio = 0.05;
 
-		// ShaderAutomaticDiscovery.cpp line 91
+		// ShaderAutomaticDiscovery.cpp line 98
 		constexpr size_t byteLengthTolerancePercent = 15;
 	}
 
@@ -138,7 +138,7 @@ namespace CrossVersionDiscoveryTest
 			return result;
 		}
 
-		// ShaderDiscovery.cpp fuzzy fallback (after exact identity miss, before reject).
+		// ShaderDiscovery.cpp fuzzy fallback (after exact identity miss, before reject; ~line 254).
 		double bestFuzzyScore = 0.0;
 		double secondBestFuzzyScore = 0.0;
 		int bestFuzzyReplacementIndex = -1;

--- a/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.cpp
+++ b/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.cpp
@@ -11,10 +11,8 @@ namespace CrossVersionDiscoveryTest
 {
 	namespace
 	{
-		// ShaderDiscovery.cpp lines 22-23
 		constexpr double maximumReplacementByteLengthDifferenceRatio = 0.05;
 
-		// ShaderAutomaticDiscovery.cpp line 98
 		constexpr size_t byteLengthTolerancePercent = 15;
 	}
 
@@ -138,7 +136,6 @@ namespace CrossVersionDiscoveryTest
 			return result;
 		}
 
-		// ShaderDiscovery.cpp fuzzy fallback (after exact identity miss, before reject; ~line 254).
 		double bestFuzzyScore = 0.0;
 		double secondBestFuzzyScore = 0.0;
 		int bestFuzzyReplacementIndex = -1;

--- a/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.h
+++ b/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.h
@@ -33,13 +33,13 @@ namespace CrossVersionDiscoveryTest
 		double secondBestFuzzyScore = 0.0;
 	};
 
-	// Mirrors ShaderDiscovery.cpp HasPlausibleByteLength (±5%, lines 51-64).
+	// Mirrors ShaderDiscovery.cpp HasPlausibleByteLength (±5%, lines 52-65).
 	bool HasPlausibleReplacementByteLength(size_t candidateLength, const ShaderTarget::ShaderTargetDisk& replacement);
 
-	// Mirrors ShaderDiscovery.cpp HasStrictCrossVersionIdentity (lines 66-72).
+	// Mirrors ShaderDiscovery.cpp HasStrictCrossVersionIdentity (lines 67-73).
 	bool HasStrictCrossVersionIdentity(const ShaderAnalysis::ShaderAnalysisDisk& analysis);
 
-	// Mirrors ShaderAutomaticDiscovery.cpp byteLengthTolerancePercent=15 (lines 91-135).
+	// Mirrors ShaderAutomaticDiscovery.cpp byteLengthTolerancePercent=15 (lines 98-141).
 	bool WouldEnqueueByByteLength(ShaderTarget::ShaderType shaderType, size_t byteLength, const std::vector<size_t>& knownTargetLengths);
 
 	// Mirrors DiscoverEnabledReplacement decision path without ShaderAnalyzer/GUI/runtime cache.

--- a/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.h
+++ b/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.h
@@ -33,16 +33,12 @@ namespace CrossVersionDiscoveryTest
 		double secondBestFuzzyScore = 0.0;
 	};
 
-	// Mirrors ShaderDiscovery.cpp HasPlausibleByteLength (±5%, lines 52-65).
 	bool HasPlausibleReplacementByteLength(size_t candidateLength, const ShaderTarget::ShaderTargetDisk& replacement);
 
-	// Mirrors ShaderDiscovery.cpp HasStrictCrossVersionIdentity (lines 67-73).
 	bool HasStrictCrossVersionIdentity(const ShaderAnalysis::ShaderAnalysisDisk& analysis);
 
-	// Mirrors ShaderAutomaticDiscovery.cpp byteLengthTolerancePercent=15 (lines 98-141).
 	bool WouldEnqueueByByteLength(ShaderTarget::ShaderType shaderType, size_t byteLength, const std::vector<size_t>& knownTargetLengths);
 
-	// Mirrors DiscoverEnabledReplacement decision path without ShaderAnalyzer/GUI/runtime cache.
 	ReplacementMatchResult EvaluateReplacementDiscovery(
 		uint64_t shaderHash,
 		ShaderTarget::ShaderType shaderType,
@@ -50,7 +46,6 @@ namespace CrossVersionDiscoveryTest
 		const ShaderAnalysis::ShaderAnalysisDisk& candidateAnalysis,
 		const std::vector<ShaderTarget::ShaderTargetDisk>& replacements);
 
-	// Mirrors DiscoverEnabledModifiedShader hash + analysis paths without ShaderAnalyzer/GUI/runtime cache.
 	ModifiedShaderMatchResult EvaluateModifiedShaderDiscovery(
 		uint64_t shaderHash,
 		ShaderTarget::ShaderType shaderType,

--- a/Tests/CrossVersionDiscovery/src/ModifiedShaderMatching.h
+++ b/Tests/CrossVersionDiscovery/src/ModifiedShaderMatching.h
@@ -14,16 +14,13 @@ namespace ModifiedShader
 
 namespace ModifiedShaderMatching
 {
-	// Mirrors ModifiedShader.cpp TargetDisk::MatchesShader (lines 46-58).
 	bool TargetMatchesShader(
 		const ModifiedShader::TargetDisk& target,
 		uint64_t shaderHash,
 		const ShaderAnalysis::ShaderAnalysisDisk& analysis);
 
-	// Mirrors ModifiedShader.cpp TargetDisk::CalculateSimilarityScore (lines 60-70).
 	double CalculateTargetSimilarityScore(const ModifiedShader::TargetDisk& left, const ModifiedShader::TargetDisk& right);
 
-	// Mirrors ModifiedShader.cpp PackageDisk::MatchesShader (lines 77-88).
 	bool PackageMatchesShader(
 		const ModifiedShader::PackageDisk& package,
 		uint64_t shaderHash,


### PR DESCRIPTION
## What this does

Adds diagnostic logging to the shader auto-discovery pipeline. Right now, if discovery fails on a player's machine, the runtime log looks identical whether it "just hasn't run yet" or is "actively failing" & there's no way to tell the difference from the log alone.

## What changed

- Logs when a captured shader gets dropped by the size-gate check (with the expected size range), and when the discovery queue is full.
- Logs when a shader almost matched a package but the similarity score was too low or too close to call between two candidates, including which fingerprint fields differed.
- Logs when analyzing a shader's fingerprint fails outright, instead of silently giving up.
- Adds a one-time check (fires once per session, after 60 seconds) that flags if a shader type we have packages for was never captured at all — a sign the problem is upstream of matching entirely.
- Cleaned up some test-file comments that referenced exact line numbers in other files, since those go stale the moment the referenced code changes.

## How I checked this

Logging-only change, no matching/decision logic touched. Verified by hand-reading both diffs against the real struct/function definitions, rebuilding the offline test suite (all cases still pass with identical results), and compiling the exact changed files on a real Windows Visual Studio install with zero errors or warnings.