### PR TITLE
fix(shader-discovery): Bytecode tolerance adjustments to better support previous versions

### DIFF
--- a/ShaderInjector/ShaderAutomaticDiscovery.cpp
+++ b/ShaderInjector/ShaderAutomaticDiscovery.cpp
@@ -95,7 +95,11 @@ namespace ShaderAutomaticDiscovery
 		bool gAnalysisWorkerRunning = false;
 		bool gAnalysisStopRequested = false;
 		bool gAcceptingWork = true;
-		constexpr size_t byteLengthTolerancePercent = 15;
+		// Newer game patches tend to compile shaders slightly smaller than the version a mod
+		// package was originally built against, so the lower bound gets more slack than the
+		// upper bound.
+		constexpr size_t byteLengthLowerTolerancePercent = 35;
+		constexpr size_t byteLengthUpperTolerancePercent = 15;
 
 		bool ParseByteLength(const std::string& byteLengthText, size_t& outByteLength)
 		{
@@ -117,10 +121,35 @@ namespace ShaderAutomaticDiscovery
 			if (shaderTypeIndex >= static_cast<size_t>(ShaderTarget::Unknown) || byteLength == 0)
 				return;
 
-			const size_t tolerance = (std::max<size_t>)(1, (byteLength * byteLengthTolerancePercent) / 100);
-			const size_t minimumLength = byteLength > tolerance ? byteLength - tolerance : 1;
-			const size_t maximumLength = byteLength + tolerance;
+			const size_t lowerTolerance = (std::max<size_t>)(1, (byteLength * byteLengthLowerTolerancePercent) / 100);
+			const size_t upperTolerance = (std::max<size_t>)(1, (byteLength * byteLengthUpperTolerancePercent) / 100);
+			const size_t minimumLength = byteLength > lowerTolerance ? byteLength - lowerTolerance : 1;
+			const size_t maximumLength = byteLength + upperTolerance;
 			gPlausibleByteLengthRanges[shaderTypeIndex].push_back({ minimumLength, maximumLength });
+		}
+
+		// Combines overlapping ranges into one sorted list per shader type, so lookups can use
+		// binary search instead of checking every range one by one.
+		void MergePlausibleByteLengthRanges()
+		{
+			for (auto& ranges : gPlausibleByteLengthRanges)
+			{
+				if (ranges.size() < 2)
+					continue;
+
+				std::sort(ranges.begin(), ranges.end());
+
+				std::vector<std::pair<size_t, size_t>> merged;
+				merged.reserve(ranges.size());
+				for (const auto& range : ranges)
+				{
+					if (!merged.empty() && range.first <= merged.back().second)
+						merged.back().second = (std::max)(merged.back().second, range.second);
+					else
+						merged.push_back(range);
+				}
+				ranges = std::move(merged);
+			}
 		}
 
 		bool HasPlausibleByteLength(ShaderTarget::ShaderType shaderType, size_t byteLength)
@@ -133,12 +162,13 @@ namespace ShaderAutomaticDiscovery
 			if (ranges.empty())
 				return true;
 
-			for (const auto& range : ranges)
-			{
-				if (byteLength >= range.first && byteLength <= range.second)
-					return true;
-			}
-			return false;
+			// Find the last range that starts at or before byteLength, then check if it fits inside it.
+			const auto it = std::upper_bound(ranges.begin(), ranges.end(), byteLength,
+				[](size_t value, const std::pair<size_t, size_t>& range) { return value < range.first; });
+			if (it == ranges.begin())
+				return false;
+			const auto& candidate = *std::prev(it);
+			return byteLength >= candidate.first && byteLength <= candidate.second;
 		}
 
 		bool TargetContainsHash(const ShaderTarget::ShaderTargetDisk& target, uint64_t shaderHash)
@@ -583,6 +613,8 @@ namespace ShaderAutomaticDiscovery
 				}
 			}
 		}
+
+		MergePlausibleByteLengthRanges();
 	}
 
 	void ProcessQueuedWork(size_t maximumJobs)

--- a/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.cpp
+++ b/Tests/CrossVersionDiscovery/src/DiscoveryLogicMirror.cpp
@@ -13,7 +13,8 @@ namespace CrossVersionDiscoveryTest
 	{
 		constexpr double maximumReplacementByteLengthDifferenceRatio = 0.05;
 
-		constexpr size_t byteLengthTolerancePercent = 15;
+		constexpr size_t byteLengthLowerTolerancePercent = 35;
+		constexpr size_t byteLengthUpperTolerancePercent = 15;
 	}
 
 	bool HasPlausibleReplacementByteLength(size_t candidateLength, const ShaderTarget::ShaderTargetDisk& replacement)
@@ -50,9 +51,10 @@ namespace CrossVersionDiscoveryTest
 			if (knownLength == 0)
 				continue;
 
-			const size_t tolerance = (std::max<size_t>)(1, (knownLength * byteLengthTolerancePercent) / 100);
-			const size_t minimumLength = knownLength > tolerance ? knownLength - tolerance : 1;
-			const size_t maximumLength = knownLength + tolerance;
+			const size_t lowerTolerance = (std::max<size_t>)(1, (knownLength * byteLengthLowerTolerancePercent) / 100);
+			const size_t upperTolerance = (std::max<size_t>)(1, (knownLength * byteLengthUpperTolerancePercent) / 100);
+			const size_t minimumLength = knownLength > lowerTolerance ? knownLength - lowerTolerance : 1;
+			const size_t maximumLength = knownLength + upperTolerance;
 			if (byteLength >= minimumLength && byteLength <= maximumLength)
 				return true;
 		}


### PR DESCRIPTION
## What
Widens the auto-discovery byte-length pre-filter and speeds up its lookup.

## Why
Log analysis on v1.004 showed real shader sizes consistently smaller than the reference size mod packages were built against, so the old ±15% tolerance was rejecting valid candidates before they ever got a chance at real matching. The gap was one-directional (always smaller, never bigger).

## Changes
- Split the tolerance into an asymmetric lower bound (35%) and upper bound (15%), so it absorbs that shrink without loosening the filter against unrelated, larger shaders. Mirrored the same change in the offline test harness.
- Swapped the per-lookup linear scan for a sorted/merged range list with binary search, since this check runs on the render thread for every candidate shader.

## Testing
- Full MSBuild compile of the changed files succeeded (link stage fails only on a pre-existing, unrelated MinHook toolchain mismatch).
- Offline test suite still passes 8/8 cases / 51/51 assertions on real 1.004/1.005 capture data.
- Verified the binary-search rewrite produces identical results to the old scan with a standalone brute-force comparison.