### PR TITLE
feat(performance): Add priority queue & skip reflection hashes for many compute shaders

### DIFF
--- a/ShaderInjector/ShaderAnalyzer.cpp
+++ b/ShaderInjector/ShaderAnalyzer.cpp
@@ -380,7 +380,11 @@ namespace ShaderAnalyzer
 		}
 	}
 
-	bool Analyze(const void* bytecode, size_t bytecodeLength, ShaderAnalysis::ShaderAnalysisDisk& outAnalysis)
+	bool Analyze(
+		const void* bytecode,
+		size_t bytecodeLength,
+		ShaderAnalysis::ShaderAnalysisDisk& outAnalysis,
+		const std::unordered_set<std::string>* acceptablePortableReflectionHashes)
 	{
 		// DXC may also be used by template creation and cached-PSO discovery on game
 		// threads. Keep all reflection/disassembly work single-file across the process.
@@ -603,19 +607,33 @@ namespace ShaderAnalyzer
 		outAnalysis.constantBufferSignatureHash = BuildConstantBufferFingerprint(outAnalysis.constantBuffers);
 		outAnalysis.instructionStatisticsHash = BuildInstructionFingerprint(outAnalysis.instructionStatistics);
 		outAnalysis.executionSignatureHash = BuildExecutionFingerprint(outAnalysis.executionProperties);
-		AnalyzeSemanticInstructions(createInstance, shaderBlob.Get(), outAnalysis);
 
+		// portableReflectionIdentityHash only needs the structured reflection data gathered
+		// above - no disassembly required - so it's available here as a cheap pre-filter before
+		// the expensive full-disassembly step below.
 		std::ostringstream portableReflectionIdentity;
 		portableReflectionIdentity << outAnalysis.shaderStage << ':' << outAnalysis.shaderModelMajor << ':' << outAnalysis.shaderModelMinor << ':'
 			<< outAnalysis.interfaceSignatureHash << ':' << outAnalysis.resourceSignatureHash << ':'
 			<< outAnalysis.constantBufferSignatureHash << ':' << outAnalysis.executionSignatureHash;
 		outAnalysis.portableReflectionIdentityHash = Fingerprint(portableReflectionIdentity.str());
 
-		if (!outAnalysis.semanticInstructionSetHash.empty())
+		// Cross-version matches always share an exact portableReflectionIdentityHash (this is
+		// already how the fuzzy replacement fallback gates its candidates). If nothing in the
+		// caller's candidate set shares this shader's reflection identity, it can never match, so
+		// skip the expensive disassembly and semantic hashing below entirely.
+		const bool skipDisassembly = acceptablePortableReflectionHashes &&
+			acceptablePortableReflectionHashes->find(outAnalysis.portableReflectionIdentityHash) ==
+				acceptablePortableReflectionHashes->end();
+
+		if (!skipDisassembly)
 		{
-			outAnalysis.crossVersionIdentityHash = Fingerprint(
-				outAnalysis.portableReflectionIdentityHash + ":" +
-				outAnalysis.entryFunctionName + ":" + outAnalysis.semanticInstructionSetHash);
+			AnalyzeSemanticInstructions(createInstance, shaderBlob.Get(), outAnalysis);
+			if (!outAnalysis.semanticInstructionSetHash.empty())
+			{
+				outAnalysis.crossVersionIdentityHash = Fingerprint(
+					outAnalysis.portableReflectionIdentityHash + ":" +
+					outAnalysis.entryFunctionName + ":" + outAnalysis.semanticInstructionSetHash);
+			}
 		}
 
 		std::ostringstream reflectionSignature;

--- a/ShaderInjector/ShaderAnalyzer.h
+++ b/ShaderInjector/ShaderAnalyzer.h
@@ -1,8 +1,22 @@
 #pragma once
 
+#include <unordered_set>
+
 #include "ShaderAnalysis.h"
 
 namespace ShaderAnalyzer
 {
-	bool Analyze(const void* bytecode, size_t bytecodeLength, ShaderAnalysis::ShaderAnalysisDisk& outAnalysis);
+	// acceptablePortableReflectionHashes is an optional pre-filter: if provided, the expensive
+	// full-disassembly step (which produces semanticInstructionSetHash/crossVersionIdentityHash)
+	// is skipped whenever the shader's cheap portableReflectionIdentityHash - available from
+	// structured reflection data alone - isn't in the set. Everything else (reflection, resource
+	// bindings, signatures, etc.) is still filled in either way, and succeeded is still true;
+	// only the disassembly-derived fields are left empty for skipped candidates. Pass nullptr to
+	// always run the full analysis (existing callers that need complete results, e.g. building
+	// replacement templates, are unaffected).
+	bool Analyze(
+		const void* bytecode,
+		size_t bytecodeLength,
+		ShaderAnalysis::ShaderAnalysisDisk& outAnalysis,
+		const std::unordered_set<std::string>* acceptablePortableReflectionHashes = nullptr);
 }

--- a/ShaderInjector/ShaderAutomaticDiscovery.cpp
+++ b/ShaderInjector/ShaderAutomaticDiscovery.cpp
@@ -216,6 +216,14 @@ namespace ShaderAutomaticDiscovery
 			return (std::max)(0.0, 1.0 - (difference / largerLength));
 		}
 
+		double ShaderTypeQueuePriorityBonus(ShaderTarget::ShaderType shaderType)
+		{
+			// Prioritize pixel shader candidates over compute shaders or other shader types for now.
+			// Currently the mod uses far more pixel shaders and these make up the bulk of the rendering
+			// replacement work.
+			return shaderType == ShaderTarget::PixelShader ? 100.0 : 0.0;
+		}
+
 		double CalculateQueuePriorityLocked(
 			ShaderTarget::ShaderType shaderType,
 			size_t byteLength,
@@ -250,7 +258,7 @@ namespace ShaderAutomaticDiscovery
 
 			// Most cross-version matches are still close in byte size. This is deliberately
 			// only a queue ordering hint; the full bytecode analysis remains the authority.
-			return bestLengthSimilarity;
+			return ShaderTypeQueuePriorityBonus(shaderType) + bestLengthSimilarity;
 		}
 
 		std::deque<QueuedShader>::iterator FindLowestPriorityQueuedShaderLocked()

--- a/ShaderInjector/ShaderDiscovery.cpp
+++ b/ShaderInjector/ShaderDiscovery.cpp
@@ -161,6 +161,7 @@ namespace ShaderDiscovery
 			return -1;
 
 		bool hasPlausibleReplacement = false;
+		std::unordered_set<std::string> acceptablePortableReflectionHashes;
 		for (const ShaderTarget::ShaderTargetDisk& replacement : replacements)
 		{
 			if (replacement.enabled && replacement.shaderType == shaderType &&
@@ -168,7 +169,10 @@ namespace ShaderDiscovery
 				HasPlausibleByteLength(shaderBytecode.size(), replacement))
 			{
 				hasPlausibleReplacement = true;
-				break;
+				// crossVersionIdentityHash always incorporates portableReflectionIdentityHash, so
+				// a candidate whose portableReflectionIdentityHash isn't among these can never
+				// produce an exact or fuzzy match below - safe to use as a cheap pre-filter.
+				acceptablePortableReflectionHashes.insert(replacement.originalShaderAnalysis.portableReflectionIdentityHash);
 			}
 		}
 
@@ -186,7 +190,8 @@ namespace ShaderDiscovery
 		}
 		else
 		{
-			ShaderAnalyzer::Analyze(shaderBytecode.data(), shaderBytecode.size(), candidateAnalysis);
+			ShaderAnalyzer::Analyze(
+				shaderBytecode.data(), shaderBytecode.size(), candidateAnalysis, &acceptablePortableReflectionHashes);
 			gReplacementCandidateAnalyses.emplace(candidateKey, candidateAnalysis);
 		}
 
@@ -472,9 +477,26 @@ namespace ShaderDiscovery
 
 		if (!haveCachedAnalysis)
 		{
+			// Cross-version matches always share an exact portableReflectionIdentityHash (cheap,
+			// no disassembly needed), so collecting the identities of compatible targets first
+			// lets Analyze() skip its expensive disassembly step for candidates that can never
+			// match anything - which is most of them.
+			std::unordered_set<std::string> acceptablePortableReflectionHashes;
+			for (const ModifiedShader::PackageDisk& package : modifiedShaders)
+			{
+				if (!package.enabled || package.shaderType != shaderType)
+					continue;
+				for (const ModifiedShader::TargetDisk& target : package.targets)
+				{
+					if (!target.shaderAnalysis.portableReflectionIdentityHash.empty())
+						acceptablePortableReflectionHashes.insert(target.shaderAnalysis.portableReflectionIdentityHash);
+				}
+			}
+
 			// This is the expensive part (DXIL reflection + disassembly), intentionally run
 			// without holding gModifiedDiscoveryMutex so worker threads run it concurrently.
-			ShaderAnalyzer::Analyze(shaderBytecode.data(), shaderBytecode.size(), candidateAnalysis);
+			ShaderAnalyzer::Analyze(
+				shaderBytecode.data(), shaderBytecode.size(), candidateAnalysis, &acceptablePortableReflectionHashes);
 			std::lock_guard<std::mutex> lock(gModifiedDiscoveryMutex);
 			gModifiedCandidateAnalyses.emplace(candidateKey, candidateAnalysis);
 		}


### PR DESCRIPTION
Speed up cross-version shader discovery by removing false serialization and skipping unnecessary bytecode analysis

### Why:
Testing on 1.004 showed the worker pool giving zero real speedup, and even after fixing that, thousands of ComputeShader false positives were burning CPU on full disassembly before ever getting rejected.

### What changed:
- Narrowed the lock in `DiscoverEnabledModifiedShader` so it only guards the shared caches, not the expensive DXIL analysis + scoring work. Previously one global mutex wrapped the entire function, so all 8 worker threads fully serialized on every candidate regardless of pool size - this was a partial reason the pool gave only a decent speedup.
- Added a shader-type priority bonus so PixelShaders (most of what mods actually replace) get analyzed before the much larger, mostly-false-positive pool of ComputeShaders.
- Added a cheap pre-filter to `ShaderAnalyzer::Analyze: compute` `portableReflectionIdentityHash` from structured reflection data (no disassembly needed) first, and only run the expensive full DXC disassembly/semantic hashing if that hash matches something in the candidate set. Cross-version matches always share this hash exactly, so this skips the costly step for candidates that could never match anyway, with no change to match behavior.

Verified: all three changed files compile cleanly against the Windows toolchain