### PR TITLE
fix(queue): Process and reprocess all pixel shaders after queue rejection

### DIFF
--- a/ShaderInjector/ShaderAutomaticDiscovery.cpp
+++ b/ShaderInjector/ShaderAutomaticDiscovery.cpp
@@ -533,7 +533,13 @@ namespace ShaderAutomaticDiscovery
 			const auto directMatchIterator = gDirectMatchShaders.find(key);
 			const bool directMatch = directMatchIterator != gDirectMatchShaders.end() &&
 				!directMatchIterator->second.empty();
-			if (!force && !directMatch && !HasPlausibleByteLength(shaderType, shaderBytecode.size()))
+			// PSOs are only ever created once by the game and never recreated, so this is the
+			// only chance a shader ever gets to be queued - anything rejected here is gone for
+			// the rest of the session. PixelShaders are rare enough (unlike ComputeShaders, which
+			// this filter genuinely needs to hold back) that there's no reason to risk losing one
+			// forever over a byte-length guess; let full analysis be the only judge for them.
+			if (!force && !directMatch && shaderType != ShaderTarget::PixelShader &&
+				!HasPlausibleByteLength(shaderType, shaderBytecode.size()))
 			{
 				++gByteLengthRejectedTotal;
 				return true;
@@ -565,7 +571,12 @@ namespace ShaderAutomaticDiscovery
 					return false;
 				}
 
-				if (!force && queuePriority <= lowestPriorityIterator->priority)
+				// Same one-shot reasoning as the byte-length gate above: a PixelShader that gets
+				// dropped here never gets a second chance. PixelShaders are rare enough that it's
+				// always worth evicting whatever the current lowest-priority queued shader is
+				// (almost always a ComputeShader) to make room, rather than risking losing this
+				// one forever.
+				if (!force && shaderType != ShaderTarget::PixelShader && queuePriority <= lowestPriorityIterator->priority)
 				{
 					gSubmittedShaders.erase(key);
 					++gQueueDroppedTotal;


### PR DESCRIPTION
## Fix pixel shader auto-discovery permanent rejection

**Why:** The game creates each shader's PSO once and does not naturally recreate them, so `Enqueue` only ever gets one shot at capturing a given shader for auto-discovery. Two of the gates inside `Enqueue` could reject a shader on that one attempt with no way to retry later — a real problem for the handful of pixel shaders the mod actually cares about (unlike the thousands of compute shaders, where these gates genuinely need to hold candidates back).

**What changed** (`ShaderAutomaticDiscovery.cpp`):
- The byte-length pre-filter no longer rejects `PixelShader` candidates. It still applies to `ComputeShader` and other types, where it's needed to cut down noise.
- The queue-full drop path no longer drops `PixelShader` candidates. When the queue is full, a pixel shader now always evicts the current lowest-priority queued item (almost always a compute shader, since pixel shaders already carry a priority bonus) instead of potentially being discarded.

**Net effect:** a pixel shader can no longer be permanently lost due to a byte-length mismatch guess or queue congestion at the one moment it's created — full similarity analysis is now the only thing that decides whether it matches a target.

**Testing:** Confirmed `ShaderAutomaticDiscovery.cpp` compiles cleanly