### PR TITLE
Report DXC diagnostics when a shader fails to compile

### DIFF
--- a/ShaderInjector/ShaderInjectorIO.cpp
+++ b/ShaderInjector/ShaderInjectorIO.cpp
@@ -23,6 +23,7 @@
 #include "ShaderTemplates.h"
 #include "Globals.h"
 #include "ProcessRunner.h"
+#include "ShaderInjectorGUI.h"
 #include "StringHelper.h"
 
 namespace ShaderInjectorIO
@@ -618,6 +619,27 @@ namespace ShaderInjectorIO
 		return GenerateShaderTextDXIL(path);
 	}
 
+	//dxc reports compilation problems on stdout/stderr. Capturing them means a failed compile
+	//can name the file, line, and reason instead of only an exit code.
+	static std::string ReadCompilerDiagnostics(const std::string& compilerOutputPath)
+	{
+		//a single mistake can cascade into a very long error list. Keep the log file readable.
+		constexpr size_t maximumDiagnosticsLength = 4000;
+
+		std::string diagnostics;
+
+		if (!ReadTextFile(compilerOutputPath, diagnostics))
+			return {};
+
+		const size_t lastContentCharacter = diagnostics.find_last_not_of(" \t\r\n");
+		diagnostics.erase(lastContentCharacter == std::string::npos ? 0 : lastContentCharacter + 1);
+
+		if (diagnostics.size() > maximumDiagnosticsLength)
+			diagnostics = diagnostics.substr(0, maximumDiagnosticsLength) + "\n... (truncated)";
+
+		return diagnostics;
+	}
+
 	//given raw HLSL human readable shader source code, compile it into a shader blob
 	bool CompileSourceToDXILBlob(const std::string& shaderSourceFilePath, const std::string& shaderProfile, const std::string& entryPoint, std::string& outBlobPath)
 	{
@@ -643,7 +665,9 @@ namespace ShaderInjectorIO
 		}
 
 		const std::string temporaryBlobPath = outBlobPath + ".compiling";
+		const std::string compilerOutputPath = temporaryBlobPath + ".log";
 		DeleteFileIfExists(temporaryBlobPath);
+		DeleteFileIfExists(compilerOutputPath);
 
 		const std::string shaderSourceDirectory = DirectoryFromPath(shaderSourceFilePath);
 		const std::string modifiedShaderIncludesDirectory = GetModifiedShadersIncludesDirectory();
@@ -659,16 +683,32 @@ namespace ShaderInjectorIO
 
 		const ProcessRunner::ProcessResult processResult = ProcessRunner::Run(
 			dxcPath,
-			dxcArguments);
+			dxcArguments,
+			compilerOutputPath);
+
+		const std::string compilerDiagnostics = ReadCompilerDiagnostics(compilerOutputPath);
+		DeleteFileIfExists(compilerOutputPath);
 
 		if (!processResult.Succeeded())
 		{
 			DeleteFileIfExists(temporaryBlobPath);
-			WriteToLogFileError(
+			ShaderInjectorGUI::WriteToRuntimeLogError(
 				"ShaderInjectorIO->CompileSourceToDXILBlob: DXC failed (exit=" +
 				std::to_string(processResult.exitCode) + "): " + processResult.errorMessage);
+
+			if (!compilerDiagnostics.empty())
+				ShaderInjectorGUI::WriteToRuntimeLogError(
+					"ShaderInjectorIO->CompileSourceToDXILBlob: " + shaderSourceFilePath +
+					" reported:\n" + compilerDiagnostics);
+
 			return false;
 		}
+
+		//a compile can succeed and still warn about something that explains an unexpected result in game.
+		if (!compilerDiagnostics.empty())
+			ShaderInjectorGUI::WriteToRuntimeLogWarning(
+				"ShaderInjectorIO->CompileSourceToDXILBlob: " + shaderSourceFilePath +
+				" reported:\n" + compilerDiagnostics);
 
 		if (!FileExists(temporaryBlobPath))
 		{


### PR DESCRIPTION
### Problem

When a modified shader fails to compile, the only thing reported is the DXC exit code:

```
[ERROR] ShaderInjectorIO->CompileSourceToDXILBlob: DXC failed (exit=-2147467259):
```

That exit code is `E_FAIL`, which says nothing about the cause. `Recompile All` then reports a bare `failed=N`.

`LiveShaderEditing.md` already notes this as a known gap, and points users at the menu's Logs section:

> *NOTE: Currently the shader injector does not provide the exact compilation errors in the logs, this should be improved on future updates.*

> Check under the `Logs` section within the shader injector menu, and correct the compilation errors.

Nothing was written there, so a user who breaks a `#define` while following the configuration guide has no way to find out what they broke, and a log attached to an issue report does not reveal it either.

### Change

`ProcessRunner::Run` already supports redirecting a child process's stdout/stderr to a file, which `GenerateShaderTextDXIL` uses. `CompileSourceToDXILBlob` now uses the same mechanism to capture DXC's output, reports it through the runtime log so it reaches both the menu and `ShaderInjector.log`, and deletes the temporary file afterwards.

Warnings from a *successful* compile are reported too, since a shader can compile and still not behave as expected.

Diagnostics are truncated at 4000 characters, because one mistake can cascade into a very long error list.

### Result

Before:

```
[ERROR] CompileSourceToDXILBlob: DXC failed (exit=-2147467259):
```

After:

```
[ERROR] CompileSourceToDXILBlob: DXC failed (exit=-2147467259):
[ERROR] CompileSourceToDXILBlob: ...GameVersion1005_PostProcessFinal_Source.hlsl reported:
...GameVersion1005_PostProcessFinal_Source.hlsl:10:49: error: use of undeclared identifier 'undeclared_thing'
float4 ShaderInjectorDiagnosticsTest() { return undeclared_thing * 2.0; }
                                                ^
```

### Testing

Built `Release|x64` and run in game on 1.0.0.5. Deliberately broke one shader, hit `Recompile All`, confirmed `compiled=43 failed=1` and that the error above appeared in both the menu's runtime log and `ShaderInjector.log`. Confirmed a clean run stays silent.

Testing this against the shipped shaders also surfaced two pre-existing warnings, present in every game-version variant:

```
ComputeShaderPass_ReflectionEnvironment.hlsl:1201:43: warning: implicit truncation of vector type [-Wconversion]
            environment.CubemapIrradiance = irradianceVolume;

ComputeShaderPass_SampleGI.hlsl:1567:27: warning: implicit truncation of vector type [-Wconversion]
    float viewSpecularHighlight = CalculateViewSpecularHighlight(worldNormal, directionToCamera, roughness);
```

Flagging those separately in case they are unintended - this PR does not change any shader source.

### Note

`ShaderInjectorIO` now includes `ShaderInjectorGUI.h` so the diagnostics reach the menu. That matches how the other non-GUI modules already log, and it is the destination the documentation points users to. Happy to route it to the log file only if you would rather keep that dependency direction.